### PR TITLE
Make "Never" keep the screen on, and keep window decorations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Changelog
 
+## 9.26.1-5 - 2026-09-10
+- Fixed "Never" not keeping the screen on (issue #189). The Power Management
+  choice was always honoured by mate-power-manager, which never blanks without
+  a timeout, but mate-screensaver activates on its own schedule -- MATE's
+  session idle-delay, five minutes by default -- and blanked and locked the
+  screen regardless. No control in Power Preferences can reach that setting,
+  so "Never" had never meant never in any Spaced release. Choosing Never now
+  also suspends screensaver idle activation, and choosing a real timeout again
+  puts the user's own screensaver choice back. A screensaver the user had
+  already switched off is never switched back on.
+- Kept window decorations for the whole session. The decorator is supervised
+  by spaced-window-decorator, but only Compiz's stored decoration command
+  started it, and Compiz reads that command once at startup. On the first
+  login after an upgrade that sets it, Compiz had already launched a bare,
+  unsupervised gtk-window-decorator; when that crashed, the session ran with
+  no titlebars or borders until the next login. An autostart entry now starts
+  the supervisor as well, and its existing lock keeps the two from racing.
+- Collected crash dumps. An elogind poweroff helper segfaulted on 9.26.1 and
+  left nothing behind but one kernel line, because the default core limit is
+  zero. Cores are now written to /var/crash, capped at 512 MB so they cannot
+  fill the disk, and pruned after a week.
+- Corrected the Spaced Update release comparison across the turn of the year.
+  Release lines are named month.year, so the line after 12.26 is 1.27, but the
+  version numbers were compared as written -- which ranks 12.26 above every
+  2027 release. From December the OS tab would have reported a year-old system
+  as current and stopped offering the upgrade. Versions are now compared in
+  calendar order.
+
 ## 9.26.1-4 - 2026-09-10
 - Stopped installing a second copy of Spaced Update. Spaced Linux ships it
   natively and the menu entry runs that copy, but Welcome also offered the

--- a/overlays/etc/cron.daily/spaced-prune-crashes
+++ b/overlays/etc/cron.daily/spaced-prune-crashes
@@ -1,0 +1,7 @@
+#!/bin/sh
+# A core dump is a diagnostic aid, not an archive. Keep a week of them so a
+# crash reported after the weekend can still be investigated, and no more.
+set -u
+[ -d /var/crash ] || exit 0
+find /var/crash -maxdepth 1 -type f -name 'core.*' -mtime +7 -delete 2>/dev/null || true
+exit 0

--- a/overlays/etc/security/limits.d/60-spaced-coredump.conf
+++ b/overlays/etc/security/limits.d/60-spaced-coredump.conf
@@ -1,0 +1,6 @@
+# The default core limit of 0 is what made the 9.26.1 elogind poweroff
+# segfault undiagnosable. Allow a bounded core rather than none: 512 MB is
+# ample for a desktop daemon and, unlike an uncapped limit, cannot fill the
+# disk. Values are in kilobytes.
+*  soft  core  524288
+*  hard  core  524288

--- a/overlays/etc/sysctl.d/60-spaced-coredump.conf
+++ b/overlays/etc/sysctl.d/60-spaced-coredump.conf
@@ -1,0 +1,8 @@
+# A desktop crash can only be diagnosed if the kernel keeps the core. The
+# elogind poweroff helper segfaulted on 9.26.1 and left nothing behind but a
+# single kernel line, because cores went to the crashing process's working
+# directory under the default pattern and were disabled outright by the
+# default limit. Collect them in one findable place instead;
+# /etc/cron.daily/spaced-prune-crashes keeps the directory from growing.
+kernel.core_pattern = /var/crash/core.%e.%p.%t
+kernel.core_uses_pid = 0

--- a/overlays/etc/xdg/autostart/spaced-window-decorator.desktop
+++ b/overlays/etc/xdg/autostart/spaced-window-decorator.desktop
@@ -1,0 +1,8 @@
+[Desktop Entry]
+Type=Application
+Name=Spaced Window Decorator
+Comment=Keep window titlebars and borders present for the whole session
+Exec=/usr/local/bin/spaced-window-decorator
+OnlyShowIn=MATE;
+NoDisplay=true
+X-MATE-Autostart-Delay=2

--- a/overlays/usr/lib/spaced-linux/spaced-update.py
+++ b/overlays/usr/lib/spaced-linux/spaced-update.py
@@ -162,8 +162,18 @@ expander > title {
 
 
 def version_key(version):
-    numbers = re.findall(r"\d+", version or "0")
-    return tuple(int(number) for number in numbers[:4])
+    # Release lines are named month.year: 9.26 is September 2026, and because
+    # the month wraps the line after 12.26 is 1.27, not 13.26. The number
+    # before the dot is therefore a calendar month and never a major version.
+    # Ordering the numbers as written ranks 12.26 above every 2027 release, so
+    # the check would call a year-old system current and stop offering the
+    # upgrade. Compare in calendar order instead: year, then month, then the
+    # patch and revision components.
+    numbers = [int(number) for number in re.findall(r"\d+", version or "0")[:4]]
+    if len(numbers) < 2:
+        return (0, 0, *numbers)
+    month, year, *patch = numbers
+    return (year, month, *patch)
 
 
 def read_installed_version():

--- a/overlays/usr/local/bin/spaced-display-repair
+++ b/overlays/usr/local/bin/spaced-display-repair
@@ -59,6 +59,45 @@ display_sleep_timeout() {
         awk '{gsub(/[^0-9-]/, "", $NF); print $NF + 0; exit}'
 }
 
+# Issue #189: choosing "Never" still let the screen go dark after five minutes.
+# The display-sleep choice only governs mate-power-manager, and it does honour
+# 0 correctly -- with no blank timeout it never enters its BLANK mode and never
+# touches DPMS. The screen was going dark because mate-screensaver activates on
+# its own schedule, at org.mate.session's idle-delay, which MATE defaults to
+# five minutes. That blanks and locks regardless of the power policy, and no
+# control in Power Preferences can reach it, so "Never" has never meant never.
+# Suppress idle activation while Never is selected and put the user's own
+# choice back when a real timeout returns.
+screensaver_state="${XDG_CONFIG_HOME:-$HOME/.config}/spaced/screensaver-idle-activation"
+
+have_screensaver() {
+    gsettings list-schemas 2>/dev/null | grep -qx org.mate.screensaver
+}
+
+suspend_screensaver_idle() {
+    local current
+    have_screensaver || return 0
+    current=$(gsettings get org.mate.screensaver idle-activation-enabled 2>/dev/null)
+    # Already off, whether by our own doing or the user's: leave it and keep
+    # any saved value, so a restore still returns what the user chose.
+    [ "$current" = false ] && return 0
+    mkdir -p "${screensaver_state%/*}" 2>/dev/null || true
+    printf '%s\n' "$current" > "$screensaver_state" 2>/dev/null || true
+    gsettings set org.mate.screensaver idle-activation-enabled false 2>/dev/null || true
+}
+
+restore_screensaver_idle() {
+    local saved
+    have_screensaver || return 0
+    # No saved value means Never was never applied here; never turn on a
+    # screensaver the user had deliberately switched off.
+    [ -r "$screensaver_state" ] || return 0
+    IFS= read -r saved < "$screensaver_state" || saved=true
+    rm -f "$screensaver_state" 2>/dev/null || true
+    [ "$saved" = false ] && return 0
+    gsettings set org.mate.screensaver idle-activation-enabled true 2>/dev/null || true
+}
+
 apply_power_policy() {
     local timeout
     gsettings list-schemas 2>/dev/null | grep -qx org.mate.power-manager || return 0
@@ -69,10 +108,12 @@ apply_power_policy() {
         xset -dpms 2>/dev/null || true
         xset s off 2>/dev/null || true
         xset s noblank 2>/dev/null || true
+        suspend_screensaver_idle
     else
         # A real timeout was chosen. Hand DPMS back to mate-power-manager
         # rather than programming a competing timeout here.
         xset +dpms 2>/dev/null || true
+        restore_screensaver_idle
     fi
 }
 

--- a/packages/spaced-mate-default-settings/DEBIAN/control
+++ b/packages/spaced-mate-default-settings/DEBIAN/control
@@ -1,5 +1,5 @@
 Package: spaced-mate-default-settings
-Version: 9.26.1-4
+Version: 9.26.1-5
 Section: x11
 Priority: optional
 Architecture: all

--- a/packages/spaced-mate-default-settings/DEBIAN/postinst
+++ b/packages/spaced-mate-default-settings/DEBIAN/postinst
@@ -45,4 +45,13 @@ if [ -x /usr/bin/flatpak ]; then
     done
 fi
 
+# Core dumps land in one findable directory. Existing installations do not
+# re-run the live-image hooks, so create the directory and apply the pattern
+# here instead of waiting for the next boot. It is world-writable with the
+# sticky bit because the kernel writes each core as the crashing user.
+install -d -m 1777 /var/crash
+if [ -r /etc/sysctl.d/60-spaced-coredump.conf ] && command -v sysctl >/dev/null 2>&1; then
+    sysctl -q -p /etc/sysctl.d/60-spaced-coredump.conf >/dev/null 2>&1 || true
+fi
+
 exit 0

--- a/packages/spaced-meta/DEBIAN/control
+++ b/packages/spaced-meta/DEBIAN/control
@@ -1,10 +1,10 @@
 Package: spaced-meta
-Version: 9.26.1-4
+Version: 9.26.1-5
 Section: metapackages
 Priority: optional
 Architecture: all
 Maintainer: Spaced Linux Team
-Depends: base-files, flatpak, libfuse2t64, libmarco-private2 (>= 1.26.2-6+spaced9.26.1), spaced-mate-default-settings (= 9.26.1-4), spaced-welcome (>= 0.1.13)
+Depends: base-files, flatpak, libfuse2t64, libmarco-private2 (>= 1.26.2-6+spaced9.26.1), spaced-mate-default-settings (= 9.26.1-5), spaced-welcome (>= 0.1.13)
 Provides: spaced-release
 Breaks: base-files (<< 13)
 Replaces: base-files (<< 13)

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -898,6 +898,28 @@ assert "ActiveChanged (false," in display_repair and not re.search(r"^\s*xset\s+
 assert "pactl subscribe" in audio_restore and "set-sink-mute" in audio_restore \
     and "set-sink-volume" in audio_restore, \
     "audio state is not restored and persisted for reappearing sinks"
+assert "org.mate.screensaver" in display_repair \
+    and "idle-activation-enabled" in display_repair, \
+    "\"Never\" still leaves mate-screensaver free to blank the screen (issue #189)"
+assert "suspend_screensaver_idle" in display_repair \
+    and "restore_screensaver_idle" in display_repair, \
+    "the screensaver override is one-way and cannot give the user's choice back"
+decorator_autostart = (root / "etc/xdg/autostart/spaced-window-decorator.desktop").read_text(encoding="utf-8")
+assert "Exec=/usr/local/bin/spaced-window-decorator" in decorator_autostart, \
+    "the decorator supervisor depends solely on Compiz's stored decoration command"
+coredump_sysctl = (root / "etc/sysctl.d/60-spaced-coredump.conf").read_text(encoding="utf-8")
+coredump_limits = (root / "etc/security/limits.d/60-spaced-coredump.conf").read_text(encoding="utf-8")
+assert "kernel.core_pattern" in coredump_sysctl and "/var/crash/" in coredump_sysctl, \
+    "a desktop crash still leaves no core behind to diagnose"
+assert "unlimited" not in coredump_limits and re.search(r"core\s+\d+", coredump_limits), \
+    "core dumps are unbounded and can fill the disk"
+assert (root / "etc/cron.daily/spaced-prune-crashes").exists(), \
+    "collected core dumps are never pruned"
+assert "etc/xdg/autostart/spaced-window-decorator.desktop" in local_package_builder \
+    and "etc/sysctl.d/60-spaced-coredump.conf" in local_package_builder \
+    and "etc/security/limits.d/60-spaced-coredump.conf" in local_package_builder \
+    and "etc/cron.daily/spaced-prune-crashes" in local_package_builder, \
+    "installed systems never receive the decorator autostart or crash-dump collection"
 finished = yaml.safe_load((root / "etc/calamares/modules/finished.conf").read_text(encoding="utf-8"))
 assert finished["restartNowCommand"] == "/sbin/reboot", \
     "Calamares uses a PATH-dependent reboot command"

--- a/scripts/iso/build-local-packages.sh
+++ b/scripts/iso/build-local-packages.sh
@@ -48,6 +48,7 @@ stage_desktop_defaults() {
         etc/apt/preferences.d \
         etc/apt/sources.list.d/spaced-apt.list \
         etc/bazaar \
+        etc/cron.daily/spaced-prune-crashes \
         etc/default/spaced-first-boot-snapshot \
         etc/fastfetch \
         etc/init.d/spaced-first-boot-snapshot \
@@ -56,7 +57,9 @@ stage_desktop_defaults() {
         etc/profile.d/spaced-flatpak-exports.sh \
         etc/profile.d/spaced-xdg-runtime.sh \
         etc/profile.d/spaced-xdg-user-dirs.sh \
+        etc/security/limits.d/60-spaced-coredump.conf \
         etc/skel \
+        etc/sysctl.d/60-spaced-coredump.conf \
         etc/brave/policies/managed/spaced-extensions.json \
         etc/xdg/autostart/spaced-audio-restore.desktop \
         etc/xdg/autostart/spaced-desktop-icon-repair.desktop \
@@ -65,6 +68,7 @@ stage_desktop_defaults() {
         etc/xdg/autostart/spaced-first-login-repair.desktop \
         etc/xdg/autostart/spaced-nvidia-postboot.desktop \
         etc/xdg/autostart/spaced-theme-monitor.desktop \
+        etc/xdg/autostart/spaced-window-decorator.desktop \
         etc/xdg/QtProject/qtquickcontrols2.conf \
         usr/lib/spaced-linux \
         usr/local/bin \

--- a/tests/test_desktop_reliability.py
+++ b/tests/test_desktop_reliability.py
@@ -203,6 +203,75 @@ HDMI-2 disconnected (normal left inverted right x axis y axis)
         self.assertEqual((self.state / 'power-writes').read_text().splitlines(),
                          ['-dpms', 's off', 's noblank'])
 
+    def fake_desktop_settings(self, timeout, screensaver=None):
+        """MATE's power schema, and optionally the screensaver schema too."""
+        schemas = ['org.mate.power-manager']
+        if screensaver is not None:
+            schemas.append('org.mate.screensaver')
+        self.command('gsettings',
+                     'case "$1" in\n'
+                     '  list-schemas) printf "%s\\n" ' + ' '.join(schemas) + ' ;;\n'
+                     '  get)\n'
+                     '    case "$2" in\n'
+                     '      org.mate.screensaver) cat "$TEST_STATE/screensaver-value" ;;\n'
+                     f'      *) echo "uint32 {timeout}" ;;\n'
+                     '    esac ;;\n'
+                     '  set)\n'
+                     '    printf "%s %s %s\\n" "$2" "$3" "$4" >> "$TEST_STATE/settings-writes"\n'
+                     '    printf "%s\\n" "$4" > "$TEST_STATE/screensaver-value" ;;\n'
+                     'esac')
+        if screensaver is not None:
+            (self.state / 'screensaver-value').write_text(f'{screensaver}\n')
+
+    def stub_display(self):
+        (self.state / 'xrandr').write_text('Screen 0: current 1920 x 1080\n'
+                                           'DP-0 connected primary 1920x1080+0+0\n')
+        self.command('xrandr', 'if [ "$*" = --prop ]; then cat "$TEST_STATE/xrandr"; else exit 0; fi')
+        self.command('xset', 'exit 0')
+
+    def settings_writes(self):
+        path = self.state / 'settings-writes'
+        return path.read_text().splitlines() if path.exists() else []
+
+    def test_never_also_stops_the_screensaver_from_blanking(self):
+        # Issue #189: "Never" was honoured by mate-power-manager, which simply
+        # never blanks without a timeout, but mate-screensaver activates on
+        # org.mate.session's own idle-delay -- five minutes by default -- and
+        # blanked the screen anyway. Power Preferences cannot reach that key,
+        # so Never has to suppress it here or it does not mean never.
+        self.stub_display()
+        self.fake_desktop_settings('0', screensaver='true')
+        self.assertEqual(self.run_helper('spaced-display-repair').returncode, 0)
+        self.assertEqual(self.settings_writes(),
+                         ['org.mate.screensaver idle-activation-enabled false'])
+
+    def test_choosing_a_timeout_restores_the_user_screensaver_choice(self):
+        self.stub_display()
+        self.fake_desktop_settings('0', screensaver='true')
+        self.assertEqual(self.run_helper('spaced-display-repair').returncode, 0)
+        # The same session now picks a real timeout again.
+        self.fake_desktop_settings('1800', screensaver='false')
+        self.assertEqual(self.run_helper('spaced-display-repair').returncode, 0)
+        self.assertEqual(self.settings_writes(), [
+            'org.mate.screensaver idle-activation-enabled false',
+            'org.mate.screensaver idle-activation-enabled true'])
+
+    def test_a_screensaver_the_user_switched_off_is_never_switched_back_on(self):
+        # Nothing was suspended, so there is nothing to restore. Turning the
+        # screensaver on here would enable a lock the user had disabled.
+        self.stub_display()
+        self.fake_desktop_settings('0', screensaver='false')
+        self.assertEqual(self.run_helper('spaced-display-repair').returncode, 0)
+        self.fake_desktop_settings('1800', screensaver='false')
+        self.assertEqual(self.run_helper('spaced-display-repair').returncode, 0)
+        self.assertEqual(self.settings_writes(), [])
+
+    def test_a_desktop_without_the_screensaver_schema_is_left_alone(self):
+        self.stub_display()
+        self.fake_desktop_settings('0')
+        self.assertEqual(self.run_helper('spaced-display-repair').returncode, 0)
+        self.assertEqual(self.settings_writes(), [])
+
     def test_audio_state_is_saved_once_per_burst_of_events(self):
         # Dragging the volume slider emits a stream of sink events. Saving on
         # each one spawned three pactl processes per event; the helper now


### PR DESCRIPTION
Four defects found while investigating an unexplained shutdown on the primary test machine. All four survive into a running session, and three of them have been present in every Spaced release.

Packaged as **9.26.1-5** so installed systems get them over APT; they are also in the tree for 9.26.2.

### Fixes #189 — "Never" never kept the screen on

The setting was not being ignored. `mate-power-manager` honours `sleep-display-ac=0` correctly: `GPM_IDLE_MODE_BLANK` is the only mode that touches DPMS, and `gpm_idle_evaluate` never schedules the blank callback when `timeout_blank` is 0.

The screen went dark because **mate-screensaver activates independently**, on `org.mate.session idle-delay` — which MATE's schema defaults to **5 minutes**, matching the reporter's symptom exactly. Spaced ships `idle-activation-enabled=true` and `lock-enabled=true` and has never overridden `idle-delay`, so every install blanks and locks after five minutes, and no control in Power Preferences can reach that key.

Choosing Never now also suspends screensaver idle activation; choosing a real timeout puts the user's own choice back. A screensaver the user had already switched off is never switched back on.

**Note for review:** while Never is selected this also suspends auto-lock on idle, because in MATE the blank and the lock are the same activation. That is the trade-off of making Never mean never; happy to change it if you'd rather keep the lock.

### Window decorations could be lost for an entire session

`spaced-window-decorator` supervises a crashed decorator, but only Compiz's stored decoration command started it — and Compiz reads that command once, at startup. The login that *first applies* the migration setting it therefore runs the old, bare `gtk-window-decorator`, unsupervised. Observed on this machine: migration marker written 21:25, Compiz started 21:24:57, decorator died at 21:25:01 on `BadWindow ... request_code 131 (XInputExtension)`, and the session had no titlebars until it was started by hand.

An autostart entry now starts the supervisor too. Its existing `flock` makes whichever instance arrives second a silent no-op.

### Crashes left nothing to diagnose

An elogind poweroff helper segfaulted on 9.26.1 and left one kernel line and no core, because the default core limit is 0. Cores now go to `/var/crash`, capped at 512 MB so they cannot fill the disk, pruned after a week. Tracked separately in #198.

### Spaced Update's release comparison broke at the year boundary

Release lines are month.year, so the line after `12.26` is `1.27`. The version numbers were compared as written, ranking `(12, 26)` above every 2027 release — from December the OS tab would have called a year-old system current. Same fix as crhy/spacedupdate#18; the overlay copy is synced here.

### Verification

- `scripts/check.sh` passes, with new assertions covering all four.
- 56 tests pass (4 new). The new #189 tests were confirmed to fail against the unpatched script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B6wVrNMeWTgHaTtY76pWbK