### PR TITLE
Give daemons a core limit, not just login sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 9.26.1-6 - 2026-09-10
+- Made crash-dump collection actually reach daemons. 9.26.1-5 raised the core
+  limit through /etc/security/limits.d, which PAM applies to login sessions
+  only. sysvinit starts services from /etc/init.d/rc without PAM, so every
+  daemon kept the default limit of 0 -- including elogind, whose poweroff
+  helper is the crash that prompted the change (issue #198). The limit is now
+  also set in /etc/default/rcS, which /etc/init.d/rc sources before it runs
+  any service script. Note that rc is #!/bin/sh and dash counts ulimit -c in
+  512-byte blocks rather than bash's 1024, so the value differs from the PAM
+  one while granting the same 512 MB.
+
 ## 9.26.1-5 - 2026-09-10
 - Fixed "Never" not keeping the screen on (issue #189). The Power Management
   choice was always honoured by mate-power-manager, which never blanks without

--- a/packages/spaced-mate-default-settings/DEBIAN/control
+++ b/packages/spaced-mate-default-settings/DEBIAN/control
@@ -1,5 +1,5 @@
 Package: spaced-mate-default-settings
-Version: 9.26.1-5
+Version: 9.26.1-6
 Section: x11
 Priority: optional
 Architecture: all

--- a/packages/spaced-mate-default-settings/DEBIAN/postinst
+++ b/packages/spaced-mate-default-settings/DEBIAN/postinst
@@ -54,4 +54,23 @@ if [ -r /etc/sysctl.d/60-spaced-coredump.conf ] && command -v sysctl >/dev/null 
     sysctl -q -p /etc/sysctl.d/60-spaced-coredump.conf >/dev/null 2>&1 || true
 fi
 
+# PAM applies /etc/security/limits.d to login sessions only. sysvinit starts
+# services from /etc/init.d/rc, which never goes through PAM, so every daemon
+# keeps the default core limit of 0 -- including elogind, whose poweroff
+# helper is the crash we cannot currently diagnose. /etc/init.d/rc sources
+# /etc/default/rcS before it runs any service script, which is the one lever
+# that reaches all of them. It is an initscripts conffile, so dpkg prompts on
+# an initscripts upgrade rather than silently reverting this.
+#
+# rc is #!/bin/sh, and dash counts ulimit -c in 512-byte blocks (bash uses
+# 1024), so 1048576 blocks is the same 512 MB the PAM limit grants.
+if [ -f /etc/default/rcS ] && ! grep -q '^ulimit -c ' /etc/default/rcS; then
+    cat >> /etc/default/rcS <<'SPACED_CORE_LIMIT'
+
+# Added by spaced-mate-default-settings: allow a bounded core dump from
+# daemons, which sysvinit starts without PAM. 512-byte blocks under dash.
+ulimit -c 1048576
+SPACED_CORE_LIMIT
+fi
+
 exit 0

--- a/packages/spaced-meta/DEBIAN/control
+++ b/packages/spaced-meta/DEBIAN/control
@@ -1,10 +1,10 @@
 Package: spaced-meta
-Version: 9.26.1-5
+Version: 9.26.1-6
 Section: metapackages
 Priority: optional
 Architecture: all
 Maintainer: Spaced Linux Team
-Depends: base-files, flatpak, libfuse2t64, libmarco-private2 (>= 1.26.2-6+spaced9.26.1), spaced-mate-default-settings (= 9.26.1-5), spaced-welcome (>= 0.1.13)
+Depends: base-files, flatpak, libfuse2t64, libmarco-private2 (>= 1.26.2-6+spaced9.26.1), spaced-mate-default-settings (= 9.26.1-6), spaced-welcome (>= 0.1.13)
 Provides: spaced-release
 Breaks: base-files (<< 13)
 Replaces: base-files (<< 13)

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -915,6 +915,8 @@ assert "unlimited" not in coredump_limits and re.search(r"core\s+\d+", coredump_
     "core dumps are unbounded and can fill the disk"
 assert (root / "etc/cron.daily/spaced-prune-crashes").exists(), \
     "collected core dumps are never pruned"
+assert "/etc/default/rcS" in defaults_postinst and "ulimit -c" in defaults_postinst, \
+    "daemons started by sysvinit never get a core limit, so elogind still cannot be diagnosed"
 assert "etc/xdg/autostart/spaced-window-decorator.desktop" in local_package_builder \
     and "etc/sysctl.d/60-spaced-coredump.conf" in local_package_builder \
     and "etc/security/limits.d/60-spaced-coredump.conf" in local_package_builder \


### PR DESCRIPTION
A defect in the crash collection shipped in 9.26.1-5. Packaged as **9.26.1-6**.

### The problem

`/etc/security/limits.d` is applied by **PAM**, which only runs for login sessions. sysvinit starts services from `/etc/init.d/rc` and never invokes PAM — `pam_limits` appears only in the `lightdm`, `sudo`, `su`, `runuser-l` and `sudo-i` stacks. So every daemon kept the default limit of 0.

Confirmed on a running 9.26.1-5 system:

```
/proc/1763/limits (elogind)   Max core file size   0   unlimited   bytes
```

Which means #198 — the crash the collection was added for — would still have produced nothing.

### The fix

`/etc/init.d/rc:50` sources `/etc/default/rcS` before it runs any service script. That is the only lever that reaches every daemon; elogind's init script sources no defaults file of its own, so there is no narrower per-service option.

`rcS` is an `initscripts` **conffile**, so dpkg prompts on an initscripts upgrade rather than silently reverting it, and the update helper's `--force-confold` keeps our value. Worth knowing: a user running plain `apt upgrade` will see a conffile prompt for `/etc/default/rcS` the next time `initscripts` changes.

### The unit trap

`rc` is `#!/bin/sh`, and **dash counts `ulimit -c` in 512-byte blocks where bash uses 1024**:

```
sh:   ulimit -c 1024  ->  524288 bytes
bash: ulimit -c 1024  -> 1048576 bytes
```

So the value is `1048576` rather than the PAM file's `524288`; both grant 512 MB. Verified by sourcing the generated block under dash and reading back `536870912`. The append is guarded, so repeated configuration adds exactly one line.

### Not systemd

To be explicit, since it came up: nothing here involves systemd. This is sysvinit's own `rc`/`rcS` mechanism. I audited the machine at the same time — PID 1 is `init [2]` from `sysvinit-core`, no `systemd`/`systemd-sysv`/`libsystemd0` is installed, `systemctl` and `journalctl` do not exist, and `loginctl` belongs to elogind. The only systemd-named packages are `systemd-standalone-sysusers` and `systemd-standalone-tmpfiles`, which depend on `libc6` alone and exist precisely so `flatpak`, `cups`, `bluez`, `chrony` and friends can satisfy their `systemd-sysusers`/`systemd-tmpfiles` dependencies **without** pulling systemd in.

### Verification

`scripts/check.sh` passes with a new assertion; 56 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B6wVrNMeWTgHaTtY76pWbK