### PR TITLE
Isolate desktop reliability test state

### DIFF
--- a/tests/test_desktop_reliability.py
+++ b/tests/test_desktop_reliability.py
@@ -124,7 +124,9 @@ class SessionTests(unittest.TestCase):
         self.state = Path(self.temp.name)
         self.fakebin = self.state / 'bin'
         self.fakebin.mkdir()
-        self.env = dict(os.environ, HOME=str(self.state), XDG_RUNTIME_DIR=str(self.state),
+        self.env = dict(os.environ, HOME=str(self.state),
+                        XDG_CONFIG_HOME=str(self.state / '.config'),
+                        XDG_RUNTIME_DIR=str(self.state),
                         DISPLAY=':spaced-test', TEST_STATE=str(self.state),
                         PATH=str(self.fakebin) + os.pathsep + os.environ['PATH'])
         self.command('logger', 'exit 0')


### PR DESCRIPTION
## Summary
- isolate desktop reliability tests from runner-level XDG configuration
- prevent screensaver state from leaking between CI workspaces

## Validation
- simulated a shared runner XDG_CONFIG_HOME
- all 92 unit tests pass
- complete make check passes