### PR TITLE
Preserve workspace ownership during Marco build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,6 +69,7 @@ cache-clean: ## Remove cached live-build packages and bootstrap data
 	$(ROOT_RUN) rm -rf "$(abspath $(CACHE_DIR))" "$(abspath $(EXTERNAL_CACHE_DIR))"
 
 marco: ## Build the upstream Marco fixes in an isolated Devuan chroot
+	mkdir -p $(BUILD_DIR)
 	if ! $(HOST_RUN) scripts/iso/stage-marco.sh --check; then
 		$(ROOT_RUN) bash "$(abspath scripts/iso/build-marco-chroot.sh)"
 	fi


### PR DESCRIPTION
## Summary
- create the build root as the invoking user before entering the privileged Marco chroot build
- prevent the subsequent live-build prepare step from failing with permission denied

## Validation
- make -n marco
- scripts/check.sh
- git diff --check

Fixes the release workflow failure in run 34687531127.