### PR TITLE
Document the published 9.26.2 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ Spaced Linux combines a modern system with visual ideas from the best desktop er
 
 ## Download Spaced Linux
 
-The release candidate is **Spaced Linux 9.26.2**. Once published, download the ISO and matching checksum from the [Spaced Linux 9.26.2 release page](https://github.com/crhy/spaced/releases/tag/v9.26.2).
+**Spaced Linux 9.26.2** is available now. Download the ISO and matching checksum from the [Spaced Linux 9.26.2 release page](https://github.com/crhy/spaced/releases/tag/v9.26.2).
 
 9.26.2 is a maintenance release for 9.26. What it fixes, and what still needs confirmation on real hardware, is recorded in the [9.26.2 issue audit](docs/9.26.2-ISSUE-STATUS.md).
 

--- a/docs/9.26.2-ISSUE-STATUS.md
+++ b/docs/9.26.2-ISSUE-STATUS.md
@@ -5,10 +5,10 @@ Audit date: 2026-09-12. This covers all 31 issues open in
 started. A source change is not treated as hardware confirmation, and roadmap
 requests are not mislabeled as point-release defects.
 
-**9.26.2 is release-gated, not published.** The distro source is versioned for
-9.26.2, but the ISO must not be published until Welcome 0.1.14 and
-SpacedBazaar 0.1.11 are released and pinned, and the acceptance checks below
-have been completed.
+**9.26.2 was published on 2026-09-12.** Welcome 0.1.14 and SpacedBazaar 0.1.11
+are released and pinned, and the automated ISO acceptance checks passed.
+Hardware-specific issues remain open until they are confirmed on the affected
+physical systems.
 
 ## Triage routing
 
@@ -27,8 +27,8 @@ have been completed.
 | [#202](https://github.com/crhy/spaced/issues/202) audio output is not remembered | Restore the saved sink by name before applying volume and mute, retain a disconnected preferred sink, support the old state format, and flush state during logout. | Select a non-default output, log out and back in, then reboot with and without that output connected. |
 | [#201](https://github.com/crhy/spaced/issues/201) display is too small | Remove the first-login DPI heuristic that overwrote MATE's selected scaling. | Upgrade and fresh-install on the affected display, then confirm scaling survives login and reboot. |
 | [#196](https://github.com/crhy/spaced/issues/196) Brave defaults | Ship the requested privacy-oriented defaults and a Telegram Web bookmark without replacing an existing profile. | Open a new Brave profile and inspect settings, policies, and bookmarks. |
-| [#195](https://github.com/crhy/spaced/issues/195) Bazaar is blank during sync | SpacedBazaar 0.1.11 keeps its startup busy state and loading view until the joined catalog synchronization task finishes. | Publish 0.1.11, launch against an empty cache, and confirm content replaces the loader only after synchronization. |
-| [#194](https://github.com/crhy/spaced/issues/194) Welcome wording | Welcome 0.1.14 identifies Bazaar as the app store and uses clearer suggested-app wording. | Publish and pin the 0.1.14 Debian package, then inspect Welcome on a fresh account. |
+| [#195](https://github.com/crhy/spaced/issues/195) Bazaar is blank during sync | SpacedBazaar 0.1.11 keeps its startup busy state and loading view until the joined catalog synchronization task finishes. | 0.1.11 is published; launch against an empty cache and confirm content replaces the loader only after synchronization. |
+| [#194](https://github.com/crhy/spaced/issues/194) Welcome wording | Welcome 0.1.14 identifies Bazaar as the app store and uses clearer suggested-app wording. | 0.1.14 is published and pinned; inspect Welcome on a fresh account. |
 | [#193](https://github.com/crhy/spaced/issues/193) Welcome app ordering | Welcome 0.1.14 reorders suggested apps, adds rhYciv, and removes the retired Spaced Update Flatpak suggestion. | Run suggested-app installation and confirm the resulting menu has one native Spaced Update entry. |
 | [#192](https://github.com/crhy/spaced/issues/192) reboot with installation USB inserted | Calamares now calls a small `zenity` confirmation helper that tells the user to remove installation media before rebooting. | Complete one BIOS and one UEFI installation and exercise both Cancel and Reboot. |
 | [#191](https://github.com/crhy/spaced/issues/191) installer desktop icon | Keep only the installer launcher on the live desktop and provide a larger scalable installer icon. | Boot the live image at normal and high DPI and inspect the desktop. |
@@ -65,17 +65,23 @@ release changes:
 - [#82](https://github.com/crhy/spaced/issues/82) Aero behavior and [#80](https://github.com/crhy/spaced/issues/80) Samba setup wizard.
 - [#53](https://github.com/crhy/spaced/issues/53) CoinMail, [#52](https://github.com/crhy/spaced/issues/52) video chat, [#50](https://github.com/crhy/spaced/issues/50) Wine integration, and [#9](https://github.com/crhy/spaced/issues/9) torrent/blockchain repositories.
 
-## Release gates
+## Release evidence
 
-1. Release Welcome 0.1.14, replace `SPACED_WELCOME_SHA256=UNRELEASED` with
-   the published Debian asset checksum, and verify its 39-test suite.
-2. Release SpacedBazaar 0.1.11 and publish its updated Flatpak catalog; verify
-   a first-run synchronization from an empty cache.
-3. Build the 9.26.2 ISO and checksum, then boot both BIOS and UEFI live images.
-4. Run the audio, display-idle, scaling, installer-reboot and desktop-icon
-   acceptance checks on representative physical hardware.
-5. Only then update or close the corresponding GitHub issues with release and
-   test evidence.
+1. Welcome 0.1.14 is published and pinned with Debian asset SHA256
+   `474d2494a14d577320da44bb494709cdd832e7058c65acb5d93a2791ea182bfb`;
+   its 39-test suite passed.
+2. SpacedBazaar 0.1.11 and its signed Flatpak catalog are published. The
+   Flatpak asset SHA256 is
+   `ac54289415da95e59adca25bf5dd1917b0d3d5d6bdd7ef1daadd90a19b1af9c6`.
+3. The official ISO workflow run
+   [34687879157](https://github.com/crhy/spaced/actions/runs/34687879157)
+   passed the clean build and BIOS, UEFI, and 4K live-desktop smoke tests at
+   tagged source commit `38ee208`.
+4. The published `spaced-linux-9.26.2-amd64.iso` is 1,796,431,872 bytes with
+   SHA256 `e2349ee2f2d8ab9dacccc9504d78c0b709ef8af15aac4069c9fcf8222335f2da`.
+5. Audio, display-idle, scaling, installer-reboot and desktop-icon acceptance
+   still require representative physical hardware before affected-system
+   issues are closed.
 
 ## Local release validation
 
@@ -89,6 +95,5 @@ release changes:
 - Package inspection passed all 135 runtime dependency checks and confirmed
   that live-only installer entrypoints are absent from the upgrade payload and
   both ordered desktop-icon repair autostarts match the authored overlays.
-- The Welcome checksum remains `UNRELEASED` in production configuration until
-  the tagged asset is built and published; ISO and hardware acceptance remain
-  open release gates.
+- The published Welcome checksum and ISO metadata pass the production release
+  gates; physical-hardware acceptance remains open where listed above.


### PR DESCRIPTION
## Summary
- mark Spaced Linux 9.26.2 as published
- record component release pins and checksums
- record the successful BIOS, UEFI, and 4K ISO validation run
- preserve physical-hardware acceptance as open evidence

## Validation
- ./scripts/check.sh
- git diff --check